### PR TITLE
print paths for all extensions

### DIFF
--- a/lint.nix
+++ b/lint.nix
@@ -29,13 +29,13 @@ let
       formatters = formatter-runners;
     };
 
-  findPattern = lib.concatMapStringsSep " -or " (ext: "-type f -name '*${ext}'");
+  findPattern = lib.concatMapStringsSep " -or " (ext: "-name '*${ext}'");
   gitPattern = lib.concatMapStringsSep " " (ext: "'*${ext}'");
   commaSep = lib.concatStringsSep ", ";
 
   formatCmd = command: stdin:
     if stdin then ''
-      (${command}) < $filename > $formatted
+      (${command}) < "$filename" > "$formatted"
     '' else ''
       cp -T --no-preserve=mode "$filename" "$formatted"
       filename="$formatted"
@@ -73,7 +73,7 @@ let
           echo
         fi
 
-      done < <(find "${src}" ${findPattern exts} -print0)
+      done < <(find "${src}" -type f \( ${findPattern exts} \) -print0)
 
       if [[ $foundDiff -eq 0 ]]; then
         echo "Success, ${name} found no differences."
@@ -132,7 +132,7 @@ let
           foundErr=1
           errs+=($filenameClean)
         fi
-      done < <(find "${src}" ${findPattern exts} -print0)
+      done < <(find "${src}" -type f \( ${findPattern exts} \) -print0)
 
       if [[ $foundErr -eq 0 ]]; then
         echo "Success, ${name} exited with code 0."

--- a/lint.nix
+++ b/lint.nix
@@ -2,6 +2,7 @@
 , formatters ? { }
 , src
 , pkgs
+, diff-cmd ? "diff --unified"
 }:
 let
   inherit (pkgs) lib;
@@ -59,7 +60,7 @@ let
 
         (${formatCmd command stdin})
 
-        if ! diff --unified "$filename" "$formatted" > "$formatted.diff" ; then
+        if ! ${diff-cmd} "$filename" "$formatted" > "$formatted.diff" ; then
 
           foundDiff=1
           filenameClean=''${filename#${src}/}
@@ -99,7 +100,7 @@ let
 
         (${formatCmd command stdin})
 
-        if ! diff --unified "$filename" "$formatted" > "$formatted.diff" ; then
+        if ! ${diff-cmd} "$filename" "$formatted" > "$formatted.diff" ; then
 
           echo "diff:"
           sed -e 's/^/      /' "$formatted.diff"


### PR DESCRIPTION
Since the -name '*.ext' -or -name '*.ext2' names weren't grouped with
parenthesis we only printed the paths for the last extension.

This PR also replaces `diff` with `delta` as the default diff tool.