### PR TITLE
Rename diff-cmd -> diffCmd, add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The configuration attribute set should contain the following fields:
 - **`linters`**: An attribute set configuring individual linters. Each should define the fields listed below. Defaults to `{ }`.
   - **`ext`**: An extension, or list of extensions, that this linter should be run on. Extensions should contain a leading period.
   - **`cmd`**: A shell script that should fail if there is an issue in `$filename`. Unlike formatters, linters do not (currently) have a `stdin` option. If your linter expects its input from `stdin`, you have to pass it manually using `cat $filename | <linter>`.
+- **`diffCmd`**: Command to produce formatting diffs. Defaults to `diff --unified`, but you might want to configure this to use something like [delta](https://github.com/dandavison/delta).
 
 The result of calling `lint-nix` is an attribute set containing the following fields:
 

--- a/lint.nix
+++ b/lint.nix
@@ -2,7 +2,7 @@
 , formatters ? { }
 , src
 , pkgs
-, diff-cmd ? "diff --unified"
+, diffCmd ? "diff --unified"
 }:
 let
   inherit (pkgs) lib;
@@ -60,7 +60,7 @@ let
 
         (${formatCmd command stdin})
 
-        if ! ${diff-cmd} "$filename" "$formatted" > "$formatted.diff" ; then
+        if ! ${diffCmd} "$filename" "$formatted" > "$formatted.diff" ; then
 
           foundDiff=1
           filenameClean=''${filename#${src}/}
@@ -100,7 +100,7 @@ let
 
         (${formatCmd command stdin})
 
-        if ! ${diff-cmd} "$filename" "$formatted" > "$formatted.diff" ; then
+        if ! ${diffCmd} "$filename" "$formatted" > "$formatted.diff" ; then
 
           echo "diff:"
           sed -e 's/^/      /' "$formatted.diff"


### PR DESCRIPTION
Renamed for consistency with nix convention for camelCase options. Or did you use kebab case for a reason @considerate?