### PR TITLE
set pipefail option for formatting check

### DIFF
--- a/lint.nix
+++ b/lint.nix
@@ -48,6 +48,7 @@ let
   checkFormatting = name: exts: command: stdin:
     pkgs.runCommandLocal "${name}-formatting-check" { } ''
       echo "Running ${name} on ${commaSep exts} files"
+      set -o pipefail
 
       foundDiff=0
       diffs=()
@@ -90,6 +91,7 @@ let
   runFormatter = name: exts: command: stdin:
     pkgs.writeShellScriptBin "run-${name}" ''
       echo "Running ${name} on ${commaSep exts} files:"
+      set -o pipefail
 
       TEMP=$(mktemp -d)
 


### PR DESCRIPTION
To ensure that we get a non-zero exit code when we pipe the diff output into a visualizer like `delta` the pipefail option has to be set.